### PR TITLE
[Helm 3.2] Change dir-mount to copy-in for the completion tests' images.

### DIFF
--- a/scripts/completion-tests/test-completion.sh
+++ b/scripts/completion-tests/test-completion.sh
@@ -118,12 +118,12 @@ trap "GOT_FAILURE=1" ERR
 BASH4_IMAGE=completion-bash4
 
 echo;echo;
-docker build -t ${BASH4_IMAGE} - <<- EOF
+docker build -t ${BASH4_IMAGE} -f - ${COMP_DIR} <<- EOF
    FROM bash:4.4
    RUN apk update && apk add bash-completion ca-certificates
+   COPY ./ ${COMP_DIR}/
 EOF
 docker run --rm \
-           -v ${COMP_DIR}:${COMP_DIR} \
            -e ROBOT_HELM_V3=${ROBOT_HELM_V3} \
            -e ROBOT_DEBUG_LEVEL=${ROBOT_DEBUG_LEVEL} \
            -e COMP_DIR=${COMP_DIR} \
@@ -139,16 +139,16 @@ docker run --rm \
 BASH3_IMAGE=completion-bash3
 
 echo;echo;
-docker build -t ${BASH3_IMAGE} - <<- EOF
+docker build -t ${BASH3_IMAGE} -f - ${COMP_DIR} <<- EOF
    FROM bash:3.2
    RUN apk update && apk add ca-certificates
    # For bash 3.2, the bash-completion package required is version 1.3
    RUN mkdir /usr/share/bash-completion && \
        wget -qO - https://github.com/scop/bash-completion/archive/1.3.tar.gz | \
             tar xvz -C /usr/share/bash-completion --strip-components 1 bash-completion-1.3/bash_completion
+   COPY ./ ${COMP_DIR}/
 EOF
 docker run --rm \
-           -v ${COMP_DIR}:${COMP_DIR} \
            -e BASH_COMPLETION=/usr/share/bash-completion \
            -e ROBOT_HELM_V3=${ROBOT_HELM_V3} \
            -e ROBOT_DEBUG_LEVEL=${ROBOT_DEBUG_LEVEL} \
@@ -163,12 +163,12 @@ docker run --rm \
 BASH_IMAGE=completion-bash-centos
 
 echo;echo;
-docker build -t ${BASH_IMAGE} - <<- EOF
+docker build -t ${BASH_IMAGE} -f - ${COMP_DIR} <<- EOF
    FROM centos
    RUN yum install -y bash-completion which
+   COPY ./ ${COMP_DIR}/
 EOF
 docker run --rm \
-           -v ${COMP_DIR}:${COMP_DIR} \
            -e ROBOT_HELM_V3=${ROBOT_HELM_V3} \
            -e ROBOT_DEBUG_LEVEL=${ROBOT_DEBUG_LEVEL} \
            -e COMP_DIR=${COMP_DIR} \
@@ -181,13 +181,13 @@ docker run --rm \
 ZSH_IMAGE=completion-zsh
 
 echo;echo;
-docker build -t ${ZSH_IMAGE} - <<- EOF
+docker build -t ${ZSH_IMAGE} -f - ${COMP_DIR} <<- EOF
    FROM zshusers/zsh:5.7
    # This will install the SSL certificates necessary for helm repo update to work
    RUN apt-get update && apt-get install -y wget
+   COPY ./ ${COMP_DIR}/
 EOF
 docker run --rm \
-           -v ${COMP_DIR}:${COMP_DIR} \
            -e ROBOT_HELM_V3=${ROBOT_HELM_V3} \
            -e ROBOT_DEBUG_LEVEL=${ROBOT_DEBUG_LEVEL} \
            -e COMP_DIR=${COMP_DIR} \
@@ -201,12 +201,12 @@ docker run --rm \
 ZSH_IMAGE=completion-zsh-alpine
 
 echo;echo;
-docker build -t ${ZSH_IMAGE} - <<- EOF
+docker build -t ${ZSH_IMAGE} -f - ${COMP_DIR} <<- EOF
    FROM alpine
    RUN apk update && apk add zsh ca-certificates
+   COPY ./ ${COMP_DIR}/
 EOF
 docker run --rm \
-           -v ${COMP_DIR}:${COMP_DIR} \
            -e ROBOT_HELM_V3=${ROBOT_HELM_V3} \
            -e ROBOT_DEBUG_LEVEL=${ROBOT_DEBUG_LEVEL} \
            -e COMP_DIR=${COMP_DIR} \


### PR DESCRIPTION
The current way of serving the completion scripts into the testing containers is a directory mount `-v ${COMP_DIR}:${COMP_DIR}` when running the containers to execute the tests.

This causes problems when trying to run the completion tests from within another container (with mounting the Docker socket). The socket is shared and so the host is shared, as well. So, the mount source in this situation comes from the upper host and not the container from where the test suite is executed.

By changing the way how the scripts are served to the test containers via copying the COMP_DIR during image build solves this problem and enables the possibility to run the completion tests in a container.